### PR TITLE
Complete Course CRUD feature for course Endpoint

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,6 +2,7 @@ from flask import Flask, jsonify
 import os
 from src.blueprints.auth import auth
 from src.blueprints.semesters import semesters
+from src.blueprints.courses import courses
 from src.constants.http_status_codes import HTTP_500_INTERNAL_SERVER_ERROR
 from src.database.database_context import db
 from flasgger import Swagger, swag_from
@@ -29,6 +30,7 @@ def create_app(test_config=None):
 
     app.register_blueprint(auth)
     app.register_blueprint(semesters)
+    app.register_blueprint(courses)
 
     Swagger(app, config=swagger_config, template=template)
 
@@ -37,3 +39,4 @@ def create_app(test_config=None):
         return jsonify({'message': 'something went wrong and we are working on it'}), HTTP_500_INTERNAL_SERVER_ERROR
 
     return app
+

--- a/src/blueprints/courses.py
+++ b/src/blueprints/courses.py
@@ -1,0 +1,36 @@
+from flask import Blueprint, request
+from src.services.course_service import create_course, get_courses, get_course_by_id, delete_course, update_course_by_id
+from flasgger import swag_from
+
+courses = Blueprint("courses", __name__, url_prefix="/api/v1/courses")
+
+
+@courses.get('/')
+# @swag_from('../docs/semesters/get_all.yaml')
+def get_all():
+    return get_courses(request.args)
+
+
+@courses.get('/<int:id>')
+# @swag_from('../docs/semesters/get.yaml')
+def get_course(id):
+    return get_course_by_id(id)
+
+
+@courses.post('/')
+# @swag_from('../docs/semesters/create.yaml')
+def create():
+    return create_course(request.get_json())
+
+
+@courses.delete('/<int:id>')
+# @swag_from('../docs/semesters/delete.yaml')
+def delete(id):
+    return delete_course(id)
+
+
+@courses.put('/<int:id>')
+@courses.patch('/<int:id>')
+# @swag_from('../docs/semesters/update.yaml')
+def update_course(id):
+    return update_course_by_id(request.get_json(), id)

--- a/src/database/database_context.py
+++ b/src/database/database_context.py
@@ -49,6 +49,14 @@ class Course(db.Model):
     title = db.Column(db.String(50), nullable=False)
     description = db.Column(db.String(50), nullable=True)
 
+    def to_dict(self):
+        return {
+            'id': self.id,
+            'code': self.code,
+            'title': self.title,
+            'description': self.description
+        }
+
     def __repr__(self) -> str:
         return 'Course>>> {self.id}'
 

--- a/src/docs/courses/create.yaml
+++ b/src/docs/courses/create.yaml
@@ -1,0 +1,54 @@
+CREATE course
+---
+tags:
+  - Courses
+parameters:
+  - in: header
+    name: Authorization
+    required: false
+  - name: body
+    description: The body should contain the course data
+    in: body
+    required: true
+    schema:
+      type: object
+      required:
+        - "code"
+        - "title"
+        - "description"
+      properties:
+        code:
+          type: "string"
+          example: "SWE 7101"
+        title:
+          type: "string"
+          example: "Advance Software Development"
+        description:
+          type: "string"
+          example: "This course explores advance software concepts"
+responses:
+  201:
+    description: When a course is successfully created
+    schema:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: 'The course ID'
+          example: 1
+        code:
+          type: "string"
+          description: 'The course code'
+          example: "SWE 7101"
+        title:
+          type: "string"
+          description: 'The course title'
+          example: "Advance Software Development"
+        description:
+          type: "string"
+          description: 'The course description'
+          example: "This course explores advance software concepts"
+  409:
+    description: When a course code already exists
+  401:
+    description: Unauthorized access

--- a/src/docs/courses/delete.yaml
+++ b/src/docs/courses/delete.yaml
@@ -1,0 +1,27 @@
+DELETE course
+---
+basePath: /api/v1
+tags:
+  - name: courses
+    description: Operations related to courses
+paths:
+  /courses/{id}:
+    delete:
+      summary: Delete a course by ID
+      description: Deletes a course with the specified ID from the database
+      tags:
+        - Courses
+      parameters:
+        - name: id
+          in: path
+          description: The ID of the course to delete
+          required: true
+          schema:
+            type: integer
+      responses:
+        '204':
+          description: Course successfully deleted
+        '401':
+          description: Unauthorized access
+        '404':
+          description: Course not found

--- a/src/docs/courses/get.yaml
+++ b/src/docs/courses/get.yaml
@@ -1,0 +1,46 @@
+GET course
+---
+basePath: /api/v1
+tags:
+  - name: courses
+    description: Operations related to courses
+paths:
+  /courses/{id}:
+    get:
+      summary: Get course by ID
+      parameters:
+        - name: id
+          in: path
+          description: ID of course to retrieve
+          required: true
+          type: integer
+      responses:
+        200:
+          description: Successfully retrieved course
+          schema:
+            type: object
+            items:
+              $ref: '#/definitions/Course'
+            properties:
+              id:
+                type: integer
+                description: ID of the course
+              code:
+                type: string
+                description: Course code
+              title:
+                type: string
+                description: Course title
+              description:
+                type: string
+                description: Course description
+        404:
+          description: Course not found
+          schema:
+            type: object
+            properties:
+              error:
+                type: string
+                description: Error message
+        401:
+          description: Unauthorized access

--- a/src/docs/courses/get_all.yaml
+++ b/src/docs/courses/get_all.yaml
@@ -1,0 +1,32 @@
+GET courses
+---
+basePath: /api/v1
+tags:
+  - name: courses
+    description: Operations related to courses
+paths:
+  /courses:
+    get:
+      summary: Retrieve all courses
+      description: Returns a list of all courses in the system.
+      responses:
+        200:
+          description: A list of courses
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/Course'
+        401:
+          description: Unauthorized access
+    definitions:
+      Course:
+        type: object
+        properties:
+          id:
+            type: integer
+          code:
+            type: string
+          title:
+            type: string
+          description:
+            type: string

--- a/src/docs/courses/update.yaml
+++ b/src/docs/courses/update.yaml
@@ -1,0 +1,56 @@
+UPDATE course
+---
+basePath: /api/v1
+paths:
+  /courses/{id}:
+    put:
+      summary: Update a course
+      tags:
+        - courses
+      parameters:
+        - in: path
+          name: id
+          required: true
+          description: The ID of the course to update
+          schema:
+            type: integer
+        - in: body
+          name: body
+          required: true
+          description: The updated course object
+          schema:
+            type: object
+            properties:
+              code:
+                type: string
+                example: "SWE72001"
+              title:
+                type: string
+                example: "Advanced Software Engineering"
+              description:
+                type: string
+                example: "Advanced topics in software engineering"
+      responses:
+        200:
+          description: Course updated successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: integer
+                    example: 1
+                  code:
+                    type: string
+                    example: "SWE72001"
+                  title:
+                    type: string
+                    example: "Advanced Software Engineering"
+                  description:
+                    type: string
+                    example: "Advanced topics in software engineering"
+        401:
+          description: Unauthorized access
+        404:
+          description: Course not found

--- a/src/services/course_service.py
+++ b/src/services/course_service.py
@@ -1,0 +1,98 @@
+from flask import jsonify
+from src.constants.http_status_codes import *
+from src.database.database_context import db, Course
+
+
+def create_course(data):
+    code = data.get('code')
+    title = data.get('title')
+    description = data.get('description')
+
+    # Query the database for a course with the given code
+    existing_course = Course.query.filter_by(code=code).first()
+
+    if existing_course:
+        return jsonify({'error_message': 'A course with with the same code already exists'}), \
+            HTTP_409_CONFLICT
+
+    new_course = Course(
+        code=code,
+        title=title,
+        description=description
+    )
+    db.session.add(new_course)
+    db.session.commit()
+
+    return jsonify(
+        {'id': new_course.id,
+         'code': new_course.code,
+         'title': new_course.title,
+         'description': new_course.description
+         }
+    ), HTTP_201_CREATED
+
+
+def get_courses(args):
+    page = args.get('page', 1, type=int)
+
+    per_page = args.get('per_page', 5, type=int)
+
+    courses = Course.query.paginate(page=page, per_page=per_page)
+
+    # List Comprehension. I have in included the to_dict function in the Course Class
+    data = [course.to_dict() for course in courses]
+
+    meta = {
+        'page': courses.page,
+        'pages': courses.pages,
+        'total_count': courses.total,
+        'prev_page': courses.prev_num,
+        'next_page': courses.next_num,
+        'has_next': courses.has_next,
+        'has_prev': courses.has_prev
+    }
+
+    return jsonify({'data': data, 'meta': meta}), HTTP_200_OK
+
+
+def get_course_by_id(id):
+    course = Course.query.get(id)
+    if course:
+        return jsonify(course.to_dict()), HTTP_200_OK
+    else:
+        return jsonify({'error_message': 'Course not found'}), HTTP_404_NOT_FOUND
+
+
+def update_course_by_id(data, id):
+    course = Course.query.get(id)
+
+    if not course:
+        return jsonify({'error_message': 'Course not found'}), HTTP_404_NOT_FOUND
+
+    # Get the updated values from the request body
+    code = data.get('code')
+    title = data.get('title')
+    description = data.get('description')
+
+    # Check if the variables are not empty then Update the course attributes with the new values
+    if code:
+        course.code = code
+    if title:
+        course.title = title
+    if description:
+        course.description = description
+
+    db.session.commit()
+    return jsonify(course.to_dict()), HTTP_200_OK
+
+
+def delete_course(id):
+    course = Course.query.get(id)
+    if course:
+        db.session.delete(course)
+        db.session.commit()
+        return jsonify({}), HTTP_204_NO_CONTENT
+    else:
+        return jsonify({'error': 'Course not found'}), HTTP_404_NOT_FOUND
+
+


### PR DESCRIPTION
This pull request includes updates to the API that allow users to create, retrieve, update, and delete courses. Specifically, it includes the following changes:

    Created the POST /courses endpoint to allow users to create new courses
    Created the GET /courses/{id} endpoint to allow users to retrieve a specific course by its ID
    Created the GET /courses endpoint to allow users to retrieve all courses
    Created the PUT /courses/{id} endpoint to allow users to update a specific course by its ID
    Created the DELETE /courses/{id} endpoint to allow users to delete a specific course by its ID
    Added Swagger YAML files for each endpoint to document the API
    
I have also added a to_dict() method to the Course model, which allows us to easily serialize course objects to JSON format.  This method is used in the GET /courses/ and GET /courses/<id> route to return a JSON representation of the course object."


All endpoints have been thoroughly tested and the API is now fully functional. Please review and merge this pull request as appropriate.
Thanks